### PR TITLE
Language per project

### DIFF
--- a/src/router/user.js
+++ b/src/router/user.js
@@ -15,6 +15,7 @@ import LayerSettings from '@/views/LayerSettings.vue'
 import PublishView from '@/views/PublishView.vue'
 import ProjectTopics from '@/views/ProjectTopics.vue'
 import ProjectAccess from '@/views/ProjectAccess.vue'
+import ProjectSettings from '@/views/ProjectSettings.vue'
 import ProjectUpdate from '@/views/ProjectUpdate.vue'
 
 Vue.use(VueRouter)
@@ -85,6 +86,11 @@ const routes = [
         path: 'access',
         name: 'access',
         component: ProjectAccess
+      },
+      {
+        path: 'settings',
+        name: 'settings',
+        component: ProjectSettings
       },
       {
         path: 'update',

--- a/src/views/ProjectSettings.vue
+++ b/src/views/ProjectSettings.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="page-content light">
+    <ScrollArea>
+      <div>
+        <h2 class="subheader px-2">Project settings</h2>
+
+        <v-select
+          class="filled"
+          label="Language"
+          v-model="settings.lang"
+          :items="availableLanguages"
+          itemValue="code"
+          itemText="title"
+        />
+      </div>
+    </ScrollArea>
+  </div>
+</template>
+
+<script>
+import ScrollArea from '@/ui/ScrollArea.vue'
+
+export default {
+  components: { ScrollArea },
+  props: {
+    project: Object,
+    settings: Object,
+  },
+  setup() {
+    return {
+      availableLanguages: [
+        {
+          id: 'en',
+          code: 'en-us',
+          title: 'English',
+        },
+        {
+          id: 'cs',
+          code: 'cs-cz',
+          title: 'Czech',
+        },
+        {
+          id: 'sk',
+          code: 'sk-sk',
+          title: 'Slovak',
+        },
+      ],
+    }
+  },
+}
+</script>

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -76,6 +76,7 @@
           <router-link class="m-2" :to="{name: 'layers'}">Layers</router-link>
           <router-link class="m-2" :to="{name: 'topics'}">Topics</router-link>
           <router-link class="m-2" :to="{name: 'access'}">Permissions</router-link>
+          <router-link class="m-2" :to="{name: 'settings'}">Settings</router-link>
           <div class="v-separator"/>
 
           <!-- <v-btn v-if="project.settings" class="small" :to="{name: 'update'}"> -->


### PR DESCRIPTION
This PR adds settings page and ability to change language per project.

Note: I am not sure where to put this selectbox in Gisquick at the moment, because there are no "project wide" settings and it settings page looks ugly with one selectbox alone. 

There is also PR for server https://github.com/gisquick/gisquick-server-next/pull/5 and client https://github.com/gisquick/gisquick/pull/165.