### PR TITLE
Topics: reorder

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "vetur": "node ./docgen.js"
   },
   "dependencies": {
+    "@vueuse/core": "^10.5.0",
+    "@vueuse/integrations": "^10.5.0",
     "axios": "^0.27.2",
     "date-fns": "^2.29.2",
     "dompurify": "^3.0.3",
@@ -16,6 +18,7 @@
     "path-browserify": "^1.0.1",
     "portal-vue": "^2.1.7",
     "proj4": "^2.8.0",
+    "sortablejs": "^1.15.0",
     "squire-rte": "^2.0.3",
     "vue": "^2.7.7",
     "vue-router": "^3.5.4"

--- a/src/components/TopicsEditor.vue
+++ b/src/components/TopicsEditor.vue
@@ -6,11 +6,13 @@
     <div class="f-col panel box">
       <v-list
         class="flat f-grow m-0"
+        item-key="id"
         empty-text="No Topics"
         item-text="title"
         :items="topics"
-        :selected="selectedIndex"
+        :selected="selectedTopic.id"
         @click-item="selectTopic"
+        :reorderable="true"
       />
       <hr/>
       <div class="toolbar f-row f-shrink">
@@ -77,7 +79,7 @@ export default {
   },
   data () {
     return {
-      selectedIndex: 0,
+      selectedTopic: 0,
       collapsed: []
     }
   },
@@ -90,7 +92,7 @@ export default {
       // return filterLayers(this.layers, l => !this.settings.layers[l.id].hidden)
     },
     activeTopic () {
-      return this.topics[this.selectedIndex]
+      return this.selectedTopic
     },
     topicLayersLookup () {
       return lookupTable(this.activeTopic.visible_overlays)
@@ -110,7 +112,8 @@ export default {
     },
     removeSelectedTopic () {
       // if (this.selectedIndex >= 0) {
-      this.topics.splice(this.selectedIndex, 1)
+      const selectedIndex = this.topics.find(topic => topic === this.selectedTopic)
+      this.topics.splice(selectedIndex, 1)
     },
     toggleLayer (layer, group) {
       if (this.topicLayersLookup[layer.id]) {
@@ -124,7 +127,7 @@ export default {
       }
     },
     selectTopic (item, index) {
-      this.selectedIndex = index
+      this.selectedTopic = item
     }
   }
 }


### PR DESCRIPTION
Adds ability to change order of topics.

- Doesn't need changes in other repositories.
- Adds following libraries:
  - sortablejs
  - `@vueuse/core` and `@vueuse/integrations` - PR uses only small part of it (`useSortable`), so if you think you don't want to include this library, it would require taking code from https://github.com/vueuse/vueuse/blob/main/packages/integrations/useSortable/index.ts

