### PR TITLE
Make settings usable on mobile

### DIFF
--- a/src/pages/user/App.vue
+++ b/src/pages/user/App.vue
@@ -171,8 +171,14 @@ html {
 }
 html, body, .app {
   height: 100%;
-  overflow: hidden;
 }
+
+@media (min-width: 1200px) {
+  html, body, .app {
+    overflow: hidden;
+  }
+}
+
 #app {
   min-height: 100;
 }

--- a/src/pages/user/index.html
+++ b/src/pages/user/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gisquick Settings</title>
   </head>
   <body tabindex="0">


### PR DESCRIPTION
At the moment, only part of the page is visible and it is not possible to scroll through the page. This PR makes settings app usable on phone devices.

![before](https://github.com/gisquick/gisquick-settings-web/assets/348276/737ad50e-938e-4311-9f6d-b1d7106641ad)
