### PR TITLE
Gisquick-settings-web: Processing service integration

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,9 +3,19 @@ name: Build and push Docker image
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'mpa-container/**'
+  workflow_run:
+    workflows: ["Build and push mpa-base"]
+    types: [completed]
+    branches: [main]
 
 jobs:
   build-and-push:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,6 +40,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            MPA_BASE_IMAGE=ghcr.io/${{ github.repository }}/mpa-base:latest
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}
             ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,35 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract short commit SHA
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/mpa-base.yml
+++ b/.github/workflows/mpa-base.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'mpa-container/**'
+      - '.github/**'
 
 jobs:
   build-mpa-base:

--- a/.github/workflows/mpa-base.yml
+++ b/.github/workflows/mpa-base.yml
@@ -1,0 +1,32 @@
+name: Build and push mpa-base
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mpa-container/**'
+
+jobs:
+  build-mpa-base:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push mpa-base
+        uses: docker/build-push-action@v5
+        with:
+          context: ./mpa-container
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/mpa-base:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY . .
 RUN npm run build
 
 
-FROM gisquick/mpa-base
+ARG MPA_BASE_IMAGE=gisquick/mpa-base
+FROM ${MPA_BASE_IMAGE}
 
 COPY --from=webapp /webapp/dist/ /var/www
 CMD ["copy-assets", "--cleanup", "static/settings/:admin/:user/", "/var/www", "/assets/"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG MPA_BASE_IMAGE=gisquick/mpa-base
+
 FROM node:16-alpine AS webapp
 
 WORKDIR /webapp/
@@ -7,7 +9,6 @@ COPY . .
 RUN npm run build
 
 
-ARG MPA_BASE_IMAGE=gisquick/mpa-base
 FROM ${MPA_BASE_IMAGE}
 
 COPY --from=webapp /webapp/dist/ /var/www

--- a/src/components/processing/ProcessBlock.vue
+++ b/src/components/processing/ProcessBlock.vue
@@ -9,8 +9,8 @@
       <v-text-field
         class="process-id-field"
         placeholder="process-id"
-        :value="proc._key"
-        @input="proc._key = $event"
+        :value="localProc._key"
+        @input="localProc._key = $event"
         @click.stop
       />
       <div class="f-grow"/>
@@ -29,20 +29,20 @@
             class="filled f-grow"
             label="Execute URL"
             placeholder="Default: {url}/processes/{id}/execution"
-            v-model="proc.remote.execute_url"
+            v-model="localProc.remote.execute_url"
           />
           <v-text-field
             class="filled"
             label="Method"
             placeholder="POST"
-            v-model="proc.remote.method"
+            v-model="localProc.remote.method"
           />
           <v-select
             class="filled"
             label="Type override"
             :items="remoteTypeItems"
-            :value="proc.remote.type || null"
-            @input="proc.remote.type = $event || ''"
+            :value="localProc.remote.type || null"
+            @input="localProc.remote.type = $event || ''"
           />
         </div>
         <div class="f-row">
@@ -50,127 +50,29 @@
             class="filled f-grow"
             label="Status URL"
             placeholder="Optional (async)"
-            v-model="proc.remote.status_url"
+            v-model="localProc.remote.status_url"
           />
           <v-text-field
             class="filled f-grow"
             label="Result URL"
             placeholder="Optional (async)"
-            v-model="proc.remote.result_url"
+            v-model="localProc.remote.result_url"
           />
         </div>
         <div class="f-row-ac mb-1 mt-1">
           <span class="field-label f-grow">Headers</span>
-          <v-btn class="icon small" @click="proc.remote.headers.push({ key: '', value: '' })">
+          <v-btn class="icon small" @click="localProc.remote.headers.push({ key: '', value: '' })">
             <v-icon name="plus" size="14"/>
           </v-btn>
         </div>
         <div
-          v-for="(h, hi) in proc.remote.headers"
+          v-for="(h, hi) in localProc.remote.headers"
           :key="'h' + hi"
           class="f-row f-align-end mb-1"
         >
           <v-text-field class="filled" label="Key" v-model="h.key"/>
           <v-text-field class="filled f-grow" label="Value" v-model="h.value"/>
-          <v-btn class="icon small" @click="proc.remote.headers.splice(hi, 1)">
-            <v-icon name="delete_forever" size="14"/>
-          </v-btn>
-        </div>
-
-        <!-- Execution -->
-        <div class="subsection-title mt-3">Execution</div>
-        <div class="f-row f-align-end">
-          <v-checkbox label="Async" v-model="proc.execution.async" class="mr-4"/>
-          <v-text-field
-            class="filled"
-            label="Poll interval (s)"
-            type="number"
-            v-model="proc.execution.poll_interval_seconds"
-          />
-          <v-text-field
-            class="filled"
-            label="Timeout (s)"
-            type="number"
-            v-model="proc.execution.timeout_seconds"
-          />
-        </div>
-
-        <!-- Project inputs -->
-        <div class="f-row-ac mt-3 mb-1">
-          <span class="subsection-title f-grow">Project Inputs</span>
-          <v-btn class="icon small" @click="addInput">
-            <v-icon name="plus" size="14"/>
-          </v-btn>
-        </div>
-        <div
-          v-for="(inp, ii) in proc.project_inputs"
-          :key="'inp' + ii"
-          class="input-block mb-2 px-2 py-2"
-        >
-          <div class="f-row f-align-end mb-1">
-            <v-text-field class="filled" label="Input ID" v-model="inp.input_id"/>
-            <v-select
-              class="filled"
-              label="Source"
-              :items="inputTypes"
-              v-model="inp._type"
-            />
-            <v-btn class="icon small" @click="proc.project_inputs.splice(ii, 1)">
-              <v-icon name="delete_forever" size="14"/>
-            </v-btn>
-          </div>
-          <template v-if="inp._type === 'layer'">
-            <v-text-field class="filled" label="Layer name/ID" v-model="inp.layer"/>
-            <div class="f-row">
-              <v-text-field
-                class="filled"
-                label="Selection mode"
-                placeholder="expression"
-                v-model="inp.selection_mode"
-              />
-              <v-text-field
-                class="filled f-grow"
-                label="Selection expression"
-                placeholder='e.g. "active" = 1'
-                v-model="inp.selection_expression"
-              />
-            </div>
-            <div class="f-row f-align-end">
-              <v-text-field
-                class="filled"
-                label="Encoding format"
-                placeholder="geojson"
-                v-model="inp.encoding_format"
-              />
-              <v-checkbox label="Geometry only" v-model="inp.encoding_geometry_only"/>
-            </div>
-          </template>
-          <template v-else>
-            <v-text-field
-              class="filled f-grow"
-              label="Value (JSON literal)"
-              placeholder='e.g. 7 or "hello" or [1,2,3]'
-              v-model="inp.value_str"
-            />
-          </template>
-        </div>
-
-        <!-- Payload bindings -->
-        <div class="f-row-ac mt-3 mb-1">
-          <span class="subsection-title f-grow">Payload Bindings</span>
-          <v-btn class="icon small" @click="proc.payload_bindings.push({ key: '', value: '' })">
-            <v-icon name="plus" size="14"/>
-          </v-btn>
-        </div>
-        <div
-          v-for="(b, bi) in proc.payload_bindings"
-          :key="'b' + bi"
-          class="f-row f-align-end mb-1"
-        >
-          <v-text-field class="filled" label="Input ID" v-model="b.key"/>
-          <v-icon name="arrow-right" size="14" class="mx-1"/>
-          <v-text-field class="filled f-grow" label="Payload path" v-model="b.value"/>
-          <v-btn class="icon small" @click="proc.payload_bindings.splice(bi, 1)">
+          <v-btn class="icon small" @click="localProc.remote.headers.splice(hi, 1)">
             <v-icon name="delete_forever" size="14"/>
           </v-btn>
         </div>
@@ -184,7 +86,7 @@
 export default {
   name: 'ProcessingProcessBlock',
   props: {
-    proc: {
+    value: {
       type: Object,
       required: true
     },
@@ -196,31 +98,22 @@ export default {
   data () {
     return {
       expanded: this.initiallyExpanded,
+      localProc: JSON.parse(JSON.stringify(this.value)),
       remoteTypeItems: [
         { text: '(Inherit from service)', value: null },
-        { text: 'OGC API Processes', value: 'ogc_api_processes' },
+        { text: 'OGC API Processes', value: 'ogcapi-processes' },
         { text: 'WPS', value: 'wps' }
       ],
-      inputTypes: [
-        { text: 'Layer', value: 'layer' },
-        { text: 'Scalar value', value: 'value' }
-      ]
     }
   },
-  methods: {
-    addInput () {
-      this.proc.project_inputs.push({
-        input_id: '',
-        _type: 'layer',
-        layer: '',
-        selection_mode: '',
-        selection_expression: '',
-        encoding_format: '',
-        encoding_geometry_only: false,
-        value_str: ''
-      })
+  watch: {
+    localProc: {
+      deep: true,
+      handler (val) {
+        this.$emit('input', val)
+      }
     }
-  }
+  },
 }
 </script>
 

--- a/src/components/processing/ProcessBlock.vue
+++ b/src/components/processing/ProcessBlock.vue
@@ -1,0 +1,283 @@
+<template>
+  <div class="process-block">
+    <div class="process-header f-row-ac px-2" @click="expanded = !expanded">
+      <v-icon
+        :name="expanded ? 'arrow-down' : 'arrow-right'"
+        size="14"
+        class="mr-2 toggle-icon"
+      />
+      <v-text-field
+        class="process-id-field"
+        placeholder="process-id"
+        :value="proc._key"
+        @input="proc._key = $event"
+        @click.stop
+      />
+      <div class="f-grow"/>
+      <v-btn class="icon small" @click.stop="$emit('remove')">
+        <v-icon name="delete_forever" size="16"/>
+      </v-btn>
+    </div>
+
+    <v-collapsible>
+      <div v-if="expanded" class="process-body px-3 py-2">
+
+        <!-- Remote -->
+        <div class="subsection-title">Remote</div>
+        <div class="f-row">
+          <v-text-field
+            class="filled f-grow"
+            label="Execute URL"
+            placeholder="Default: {url}/processes/{id}/execution"
+            v-model="proc.remote.execute_url"
+          />
+          <v-text-field
+            class="filled"
+            label="Method"
+            placeholder="POST"
+            v-model="proc.remote.method"
+          />
+          <v-select
+            class="filled"
+            label="Type override"
+            :items="remoteTypeItems"
+            :value="proc.remote.type || null"
+            @input="proc.remote.type = $event || ''"
+          />
+        </div>
+        <div class="f-row">
+          <v-text-field
+            class="filled f-grow"
+            label="Status URL"
+            placeholder="Optional (async)"
+            v-model="proc.remote.status_url"
+          />
+          <v-text-field
+            class="filled f-grow"
+            label="Result URL"
+            placeholder="Optional (async)"
+            v-model="proc.remote.result_url"
+          />
+        </div>
+        <div class="f-row-ac mb-1 mt-1">
+          <span class="field-label f-grow">Headers</span>
+          <v-btn class="icon small" @click="proc.remote.headers.push({ key: '', value: '' })">
+            <v-icon name="plus" size="14"/>
+          </v-btn>
+        </div>
+        <div
+          v-for="(h, hi) in proc.remote.headers"
+          :key="'h' + hi"
+          class="f-row f-align-end mb-1"
+        >
+          <v-text-field class="filled" label="Key" v-model="h.key"/>
+          <v-text-field class="filled f-grow" label="Value" v-model="h.value"/>
+          <v-btn class="icon small" @click="proc.remote.headers.splice(hi, 1)">
+            <v-icon name="delete_forever" size="14"/>
+          </v-btn>
+        </div>
+
+        <!-- Execution -->
+        <div class="subsection-title mt-3">Execution</div>
+        <div class="f-row f-align-end">
+          <v-checkbox label="Async" v-model="proc.execution.async" class="mr-4"/>
+          <v-text-field
+            class="filled"
+            label="Poll interval (s)"
+            type="number"
+            v-model="proc.execution.poll_interval_seconds"
+          />
+          <v-text-field
+            class="filled"
+            label="Timeout (s)"
+            type="number"
+            v-model="proc.execution.timeout_seconds"
+          />
+        </div>
+
+        <!-- Project inputs -->
+        <div class="f-row-ac mt-3 mb-1">
+          <span class="subsection-title f-grow">Project Inputs</span>
+          <v-btn class="icon small" @click="addInput">
+            <v-icon name="plus" size="14"/>
+          </v-btn>
+        </div>
+        <div
+          v-for="(inp, ii) in proc.project_inputs"
+          :key="'inp' + ii"
+          class="input-block mb-2 px-2 py-2"
+        >
+          <div class="f-row f-align-end mb-1">
+            <v-text-field class="filled" label="Input ID" v-model="inp.input_id"/>
+            <v-select
+              class="filled"
+              label="Source"
+              :items="inputTypes"
+              v-model="inp._type"
+            />
+            <v-btn class="icon small" @click="proc.project_inputs.splice(ii, 1)">
+              <v-icon name="delete_forever" size="14"/>
+            </v-btn>
+          </div>
+          <template v-if="inp._type === 'layer'">
+            <v-text-field class="filled" label="Layer name/ID" v-model="inp.layer"/>
+            <div class="f-row">
+              <v-text-field
+                class="filled"
+                label="Selection mode"
+                placeholder="expression"
+                v-model="inp.selection_mode"
+              />
+              <v-text-field
+                class="filled f-grow"
+                label="Selection expression"
+                placeholder='e.g. "active" = 1'
+                v-model="inp.selection_expression"
+              />
+            </div>
+            <div class="f-row f-align-end">
+              <v-text-field
+                class="filled"
+                label="Encoding format"
+                placeholder="geojson"
+                v-model="inp.encoding_format"
+              />
+              <v-checkbox label="Geometry only" v-model="inp.encoding_geometry_only"/>
+            </div>
+          </template>
+          <template v-else>
+            <v-text-field
+              class="filled f-grow"
+              label="Value (JSON literal)"
+              placeholder='e.g. 7 or "hello" or [1,2,3]'
+              v-model="inp.value_str"
+            />
+          </template>
+        </div>
+
+        <!-- Payload bindings -->
+        <div class="f-row-ac mt-3 mb-1">
+          <span class="subsection-title f-grow">Payload Bindings</span>
+          <v-btn class="icon small" @click="proc.payload_bindings.push({ key: '', value: '' })">
+            <v-icon name="plus" size="14"/>
+          </v-btn>
+        </div>
+        <div
+          v-for="(b, bi) in proc.payload_bindings"
+          :key="'b' + bi"
+          class="f-row f-align-end mb-1"
+        >
+          <v-text-field class="filled" label="Input ID" v-model="b.key"/>
+          <v-icon name="arrow-right" size="14" class="mx-1"/>
+          <v-text-field class="filled f-grow" label="Payload path" v-model="b.value"/>
+          <v-btn class="icon small" @click="proc.payload_bindings.splice(bi, 1)">
+            <v-icon name="delete_forever" size="14"/>
+          </v-btn>
+        </div>
+
+      </div>
+    </v-collapsible>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ProcessingProcessBlock',
+  props: {
+    proc: {
+      type: Object,
+      required: true
+    },
+    initiallyExpanded: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data () {
+    return {
+      expanded: this.initiallyExpanded,
+      remoteTypeItems: [
+        { text: '(Inherit from service)', value: null },
+        { text: 'OGC API Processes', value: 'ogc_api_processes' },
+        { text: 'WPS', value: 'wps' }
+      ],
+      inputTypes: [
+        { text: 'Layer', value: 'layer' },
+        { text: 'Scalar value', value: 'value' }
+      ]
+    }
+  },
+  methods: {
+    addInput () {
+      this.proc.project_inputs.push({
+        input_id: '',
+        _type: 'layer',
+        layer: '',
+        selection_mode: '',
+        selection_expression: '',
+        encoding_format: '',
+        encoding_geometry_only: false,
+        value_str: ''
+      })
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.process-block {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.process-header {
+  height: 38px;
+  background-color: #eee;
+  cursor: pointer;
+  user-select: none;
+  border-bottom: 1px solid #ddd;
+  &:hover {
+    background-color: #e4e4e4;
+  }
+}
+
+.toggle-icon {
+  flex-shrink: 0;
+}
+
+.process-id-field {
+  font-size: 13.5px;
+  font-weight: 500;
+  ::v-deep .input-field {
+    border: none;
+    background: transparent;
+    font-weight: 500;
+  }
+}
+
+.process-body {
+  background-color: #fafafa;
+}
+
+.subsection-title {
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #666;
+  margin-bottom: 4px;
+}
+
+.field-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #666;
+}
+
+.input-block {
+  border: 1px solid #e0e0e0;
+  border-radius: 3px;
+  background-color: #fff;
+}
+</style>

--- a/src/components/processing/ProcessBlock.vue
+++ b/src/components/processing/ProcessBlock.vue
@@ -1,18 +1,12 @@
 <template>
   <div class="process-block">
-    <div class="process-header f-row-ac px-2" @click="expanded = !expanded">
+    <div class="process-header f-row-ac px-2" :class="{ expanded }" @click="expanded = !expanded">
       <v-icon
         :name="expanded ? 'arrow-down' : 'arrow-right'"
         size="14"
         class="mr-2 toggle-icon"
       />
-      <v-text-field
-        class="process-id-field"
-        placeholder="process-id"
-        :value="localProc._key"
-        @input="localProc._key = $event"
-        @click.stop
-      />
+      <span class="process-id">{{ value._key }}</span>
       <div class="f-grow"/>
       <v-btn class="icon small" @click.stop="$emit('remove')">
         <v-icon name="delete_forever" size="16"/>
@@ -20,63 +14,27 @@
     </div>
 
     <v-collapsible>
-      <div v-if="expanded" class="process-body px-3 py-2">
-
-        <!-- Remote -->
-        <div class="subsection-title">Remote</div>
-        <div class="f-row">
-          <v-text-field
-            class="filled f-grow"
-            label="Execute URL"
-            placeholder="Default: {url}/processes/{id}/execution"
-            v-model="localProc.remote.execute_url"
-          />
-          <v-text-field
-            class="filled"
-            label="Method"
-            placeholder="POST"
-            v-model="localProc.remote.method"
-          />
-          <v-select
-            class="filled"
-            label="Type override"
-            :items="remoteTypeItems"
-            :value="localProc.remote.type || null"
-            @input="localProc.remote.type = $event || ''"
-          />
-        </div>
-        <div class="f-row">
-          <v-text-field
-            class="filled f-grow"
-            label="Status URL"
-            placeholder="Optional (async)"
-            v-model="localProc.remote.status_url"
-          />
-          <v-text-field
-            class="filled f-grow"
-            label="Result URL"
-            placeholder="Optional (async)"
-            v-model="localProc.remote.result_url"
-          />
-        </div>
-        <div class="f-row-ac mb-1 mt-1">
-          <span class="field-label f-grow">Headers</span>
-          <v-btn class="icon small" @click="localProc.remote.headers.push({ key: '', value: '' })">
-            <v-icon name="plus" size="14"/>
-          </v-btn>
-        </div>
-        <div
-          v-for="(h, hi) in localProc.remote.headers"
-          :key="'h' + hi"
-          class="f-row f-align-end mb-1"
-        >
-          <v-text-field class="filled" label="Key" v-model="h.key"/>
-          <v-text-field class="filled f-grow" label="Value" v-model="h.value"/>
-          <v-btn class="icon small" @click="localProc.remote.headers.splice(hi, 1)">
-            <v-icon name="delete_forever" size="14"/>
-          </v-btn>
-        </div>
-
+      <div v-if="expanded" class="process-body">
+        <template v-if="desc">
+          <div v-if="desc.title && desc.title !== value._key" class="proc-title">
+            {{ desc.title }}
+          </div>
+          <div v-if="desc.description" class="proc-description">
+            {{ desc.description }}
+          </div>
+          <template v-if="inputs.length">
+            <div class="subsection-title">Inputs</div>
+            <div
+              v-for="inp in inputs"
+              :key="inp.name"
+              class="proc-input"
+            >
+              <span class="inp-name">{{ inp.name }}</span>
+              <span v-if="inp.description" class="inp-desc">{{ inp.description }}</span>
+            </div>
+          </template>
+        </template>
+        <div v-else class="proc-description no-desc">No description available.</div>
       </div>
     </v-collapsible>
   </div>
@@ -97,23 +55,22 @@ export default {
   },
   data () {
     return {
-      expanded: this.initiallyExpanded,
-      localProc: JSON.parse(JSON.stringify(this.value)),
-      remoteTypeItems: [
-        { text: '(Inherit from service)', value: null },
-        { text: 'OGC API Processes', value: 'ogcapi-processes' },
-        { text: 'WPS', value: 'wps' }
-      ],
+      expanded: this.initiallyExpanded
     }
   },
-  watch: {
-    localProc: {
-      deep: true,
-      handler (val) {
-        this.$emit('input', val)
-      }
+  computed: {
+    desc () {
+      return this.value.description || null
+    },
+    inputs () {
+      const inp = this.desc && this.desc.inputs
+      if (!inp) return []
+      return Object.entries(inp).map(([name, def]) => ({
+        name,
+        description: def.description || def.title || ''
+      }))
     }
-  },
+  }
 }
 </script>
 
@@ -125,13 +82,20 @@ export default {
 }
 
 .process-header {
-  height: 38px;
+  height: 42px;
   background-color: #eee;
   cursor: pointer;
   user-select: none;
-  border-bottom: 1px solid #ddd;
+  border-left: 3px solid transparent;
+  transition: background-color 0.15s, border-color 0.15s;
+
   &:hover {
     background-color: #e4e4e4;
+  }
+
+  &.expanded {
+    border-left-color: var(--color-primary);
+    border-bottom: 1px solid #ddd;
   }
 }
 
@@ -139,38 +103,72 @@ export default {
   flex-shrink: 0;
 }
 
-.process-id-field {
+.process-id {
   font-size: 13.5px;
   font-weight: 500;
-  ::v-deep .input-field {
-    border: none;
-    background: transparent;
-    font-weight: 500;
-  }
 }
 
 .process-body {
+  padding: 14px 16px;
   background-color: #fafafa;
+}
+
+.proc-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 4px;
+}
+
+.proc-description {
+  font-size: 13px;
+  color: #555;
+  line-height: 1.5;
+  margin-bottom: 12px;
+  max-width: 640px;
+
+  &.no-desc {
+    font-style: italic;
+    color: #aaa;
+    margin-bottom: 0;
+  }
 }
 
 .subsection-title {
   font-weight: 600;
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #666;
-  margin-bottom: 4px;
+  letter-spacing: 0.07em;
+  color: rgba(46, 108, 158, 0.85);
+  margin-bottom: 8px;
 }
 
-.field-label {
-  font-size: 12px;
-  font-weight: 500;
-  color: #666;
+.proc-input {
+  padding: 5px 0 5px 10px;
+  border-left: 2px solid #e0e0e0;
+  margin-bottom: 6px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
-.input-block {
-  border: 1px solid #e0e0e0;
+.inp-name {
+  display: inline-block;
+  background: rgba(46, 108, 158, 0.09);
+  color: rgb(46, 108, 158);
   border-radius: 3px;
-  background-color: #fff;
+  padding: 1px 5px;
+  font-size: 12px;
+  font-family: monospace;
+  font-weight: 600;
+}
+
+.inp-desc {
+  display: block;
+  margin-top: 3px;
+  font-size: 12px;
+  color: #666;
+  line-height: 1.4;
 }
 </style>

--- a/src/components/processing/ServiceForm.vue
+++ b/src/components/processing/ServiceForm.vue
@@ -35,7 +35,8 @@
       <process-block
         v-for="(proc, pi) in service._processes"
         :key="pi"
-        :proc="proc"
+        :value="proc"
+        @input="$set(service._processes, pi, $event)"
         :initially-expanded="pi === newProcessIndex"
         class="mb-3"
         @remove="removeProcess(pi)"
@@ -65,7 +66,7 @@ import ProcessBlock from './ProcessBlock.vue'
 import { processToEdit } from '@/utils/processing'
 
 const SERVICE_TYPES = [
-  { text: 'OGC API Processes', value: 'ogc_api_processes' },
+  { text: 'OGC API Processes', value: 'ogcapi-processes' },
   { text: 'WPS', value: 'wps' }
 ]
 

--- a/src/components/processing/ServiceForm.vue
+++ b/src/components/processing/ServiceForm.vue
@@ -46,7 +46,7 @@
       <div class="f-row-ac mt-4 mb-2">
         <span class="section-title f-grow">Processes</span>
         <v-btn
-          v-if="!isNew && service.type === 'ogcapi-processes'"
+          v-if="!isNew"
           class="small n-case"
           :disabled="syncing"
           @click="$emit('sync')"

--- a/src/components/processing/ServiceForm.vue
+++ b/src/components/processing/ServiceForm.vue
@@ -1,0 +1,121 @@
+<template>
+  <v-scroll-area class="service-form f-col f-grow">
+    <div class="f-col px-4 py-3">
+
+      <!-- Basic service fields -->
+      <div class="section-title mb-2">Service</div>
+      <div class="f-row">
+        <v-text-field
+          class="filled f-grow"
+          label="URL *"
+          v-model="service.url"
+        />
+        <v-select
+          class="filled"
+          label="Type"
+          :items="serviceTypes"
+          v-model="service.type"
+        />
+      </div>
+      <v-text-field
+        class="filled"
+        label="Name"
+        v-model="service.name"
+      />
+
+      <!-- Per-process proxy config -->
+      <div class="f-row-ac mt-4 mb-2">
+        <span class="section-title f-grow">Per-Process Proxy Config</span>
+        <v-btn class="small n-case" color="green" @click="addProcess">
+          <v-icon name="plus" class="mr-1"/>
+          <span>Add process</span>
+        </v-btn>
+      </div>
+
+      <process-block
+        v-for="(proc, pi) in service._processes"
+        :key="pi"
+        :proc="proc"
+        :initially-expanded="pi === newProcessIndex"
+        class="mb-3"
+        @remove="removeProcess(pi)"
+      />
+
+      <!-- Save / Cancel -->
+      <div class="f-row mt-4">
+        <v-btn
+          color="primary"
+          :disabled="!service.url || saving"
+          @click="$emit('save')"
+        >
+          <v-icon name="save" class="mr-2"/>
+          <span>{{ isNew ? 'Add Service' : 'Save Service' }}</span>
+        </v-btn>
+        <v-btn v-if="isNew" class="ml-2" @click="$emit('cancel')">
+          Cancel
+        </v-btn>
+      </div>
+
+    </div>
+  </v-scroll-area>
+</template>
+
+<script>
+import ProcessBlock from './ProcessBlock.vue'
+import { processToEdit } from '@/utils/processing'
+
+const SERVICE_TYPES = [
+  { text: 'OGC API Processes', value: 'ogc_api_processes' },
+  { text: 'WPS', value: 'wps' }
+]
+
+export default {
+  name: 'ProcessingServiceForm',
+  components: { ProcessBlock },
+  props: {
+    service: {
+      type: Object,
+      required: true
+    },
+    isNew: {
+      type: Boolean,
+      default: false
+    },
+    saving: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data () {
+    return {
+      serviceTypes: SERVICE_TYPES,
+      newProcessIndex: null
+    }
+  },
+  methods: {
+    addProcess () {
+      this.service._processes.push(processToEdit('', {}))
+      this.newProcessIndex = this.service._processes.length - 1
+    },
+    removeProcess (index) {
+      this.service._processes.splice(index, 1)
+      this.newProcessIndex = null
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.service-form {
+  min-height: 0;
+  flex: 1 1 0;
+}
+
+.section-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: #444;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+</style>

--- a/src/components/processing/ServiceForm.vue
+++ b/src/components/processing/ServiceForm.vue
@@ -23,9 +23,28 @@
         v-model="service.name"
       />
 
-      <!-- Per-process proxy config -->
+      <!-- Service-level headers -->
+      <div class="f-row-ac mt-4 mb-1">
+        <span class="section-title f-grow">Headers</span>
+        <v-btn class="icon small" @click="service._headers.push({ key: '', value: '' })">
+          <v-icon name="plus" size="14"/>
+        </v-btn>
+      </div>
+      <div
+        v-for="(h, hi) in service._headers"
+        :key="'h' + hi"
+        class="f-row f-align-end mb-1"
+      >
+        <v-text-field class="filled" label="Key" v-model="h.key"/>
+        <v-text-field class="filled f-grow" label="Value" v-model="h.value"/>
+        <v-btn class="icon small" @click="service._headers.splice(hi, 1)">
+          <v-icon name="delete_forever" size="14"/>
+        </v-btn>
+      </div>
+
+      <!-- Processes -->
       <div class="f-row-ac mt-4 mb-2">
-        <span class="section-title f-grow">Per-Process Proxy Config</span>
+        <span class="section-title f-grow">Processes</span>
         <v-btn
           v-if="!isNew && service.type === 'ogcapi-processes'"
           class="small n-case"
@@ -41,7 +60,6 @@
         v-for="(proc, pi) in service._processes"
         :key="pi"
         :value="proc"
-        @input="$set(service._processes, pi, $event)"
         class="mb-3"
         @remove="removeProcess(pi)"
       />

--- a/src/components/processing/ServiceForm.vue
+++ b/src/components/processing/ServiceForm.vue
@@ -26,9 +26,14 @@
       <!-- Per-process proxy config -->
       <div class="f-row-ac mt-4 mb-2">
         <span class="section-title f-grow">Per-Process Proxy Config</span>
-        <v-btn class="small n-case" color="green" @click="addProcess">
-          <v-icon name="plus" class="mr-1"/>
-          <span>Add process</span>
+        <v-btn
+          v-if="!isNew && service.type === 'ogcapi-processes'"
+          class="small n-case"
+          :disabled="syncing"
+          @click="$emit('sync')"
+        >
+          <v-icon name="reload" class="mr-1"/>
+          <span>{{ syncing ? 'Refreshing…' : 'Refresh processes' }}</span>
         </v-btn>
       </div>
 
@@ -37,7 +42,6 @@
         :key="pi"
         :value="proc"
         @input="$set(service._processes, pi, $event)"
-        :initially-expanded="pi === newProcessIndex"
         class="mb-3"
         @remove="removeProcess(pi)"
       />
@@ -63,7 +67,6 @@
 
 <script>
 import ProcessBlock from './ProcessBlock.vue'
-import { processToEdit } from '@/utils/processing'
 
 const SERVICE_TYPES = [
   { text: 'OGC API Processes', value: 'ogcapi-processes' },
@@ -85,22 +88,20 @@ export default {
     saving: {
       type: Boolean,
       default: false
+    },
+    syncing: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
     return {
-      serviceTypes: SERVICE_TYPES,
-      newProcessIndex: null
+      serviceTypes: SERVICE_TYPES
     }
   },
   methods: {
-    addProcess () {
-      this.service._processes.push(processToEdit('', {}))
-      this.newProcessIndex = this.service._processes.length - 1
-    },
     removeProcess (index) {
       this.service._processes.splice(index, 1)
-      this.newProcessIndex = null
     }
   }
 }

--- a/src/components/processing/ServicesList.vue
+++ b/src/components/processing/ServicesList.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="processing-services-list f-col">
+    <div class="panel-header f-row-ac px-2">
+      <span class="f-grow">Services</span>
+      <v-btn class="icon small" title="Add service" @click="$emit('add')">
+        <v-icon name="plus"/>
+      </v-btn>
+    </div>
+    <div class="list f-col">
+      <div v-if="!services.length" class="empty-hint px-2 py-3">
+        No services configured
+      </div>
+      <div
+        v-for="(svc, i) in services"
+        :key="i"
+        class="service-item f-row-ac px-2"
+        :class="{ active: selectedIndex === i && !isNew }"
+        @click="$emit('select', i)"
+      >
+        <span class="f-grow item-label" v-text="svc.name || svc.url || '(unnamed)'"/>
+        <v-btn class="icon small" @click.stop="$emit('delete', i)">
+          <v-icon name="delete_forever" size="16"/>
+        </v-btn>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ProcessingServicesList',
+  props: {
+    services: {
+      type: Array,
+      default: () => []
+    },
+    selectedIndex: {
+      type: Number,
+      default: null
+    },
+    isNew: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.processing-services-list {
+  width: 220px;
+  flex-shrink: 0;
+  border-right: 1px solid #ddd;
+  background-color: #f5f5f5;
+}
+
+.panel-header {
+  height: 38px;
+  font-weight: 500;
+  font-size: 14px;
+  border-bottom: 1px solid #ddd;
+  background-color: #eee;
+  flex-shrink: 0;
+}
+
+.list {
+  flex: 1 1 0;
+}
+
+.service-item {
+  height: 36px;
+  cursor: pointer;
+  border-bottom: 1px solid #e8e8e8;
+  font-size: 13.5px;
+  &:hover {
+    background-color: #e8e8e8;
+  }
+  &.active {
+    background-color: var(--color-primary);
+    color: #fff;
+    --fill-color: #fff;
+  }
+}
+
+.item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.empty-hint {
+  font-size: 13px;
+  color: #999;
+  font-style: italic;
+}
+</style>

--- a/src/components/processing/ServicesList.vue
+++ b/src/components/processing/ServicesList.vue
@@ -11,14 +11,14 @@
         No services configured
       </div>
       <div
-        v-for="(svc, i) in services"
-        :key="i"
+        v-for="svc in services"
+        :key="svc.id"
         class="service-item f-row-ac px-2"
-        :class="{ active: selectedIndex === i && !isNew }"
-        @click="$emit('select', i)"
+        :class="{ active: selectedId === svc.id && !isNew }"
+        @click="$emit('select', svc.id)"
       >
         <span class="f-grow item-label" v-text="svc.name || svc.url || '(unnamed)'"/>
-        <v-btn class="icon small" @click.stop="$emit('delete', i)">
+        <v-btn class="icon small" @click.stop="$emit('delete', svc.id)">
           <v-icon name="delete_forever" size="16"/>
         </v-btn>
       </div>
@@ -34,8 +34,8 @@ export default {
       type: Array,
       default: () => []
     },
-    selectedIndex: {
-      type: Number,
+    selectedId: {
+      type: String,
       default: null
     },
     isNew: {

--- a/src/router/user.js
+++ b/src/router/user.js
@@ -17,6 +17,7 @@ import ProjectTopics from '@/views/ProjectTopics.vue'
 import ProjectAccess from '@/views/ProjectAccess.vue'
 import ProjectUpdate from '@/views/ProjectUpdate.vue'
 import SearchView from '@/views/SearchView.vue'
+import ProcessingView from '@/views/ProcessingView.vue'
 
 Vue.use(VueRouter)
 
@@ -86,6 +87,11 @@ const routes = [
         path: 'search',
         name: 'search',
         component: SearchView
+      },
+      {
+        path: 'processing',
+        name: 'processing',
+        component: ProcessingView
       },
       {
         path: 'access',

--- a/src/utils/processing.js
+++ b/src/utils/processing.js
@@ -1,0 +1,121 @@
+export function objToKvPairs (obj) {
+  if (!obj || typeof obj !== 'object') return []
+  return Object.entries(obj).map(([key, value]) => ({ key, value: String(value) }))
+}
+
+export function kvPairsToObj (pairs) {
+  const obj = {}
+  for (const { key, value } of pairs) {
+    if (key) obj[key] = value
+  }
+  return obj
+}
+
+export function processToEdit (id, cfg) {
+  return {
+    _key: id,
+    remote: {
+      type: cfg.remote?.type || '',
+      execute_url: cfg.remote?.execute_url || '',
+      method: cfg.remote?.method || '',
+      status_url: cfg.remote?.status_url || '',
+      result_url: cfg.remote?.result_url || '',
+      headers: objToKvPairs(cfg.remote?.headers || {})
+    },
+    execution: {
+      async: cfg.execution?.async || false,
+      poll_interval_seconds: cfg.execution?.poll_interval_seconds != null
+        ? String(cfg.execution.poll_interval_seconds)
+        : '',
+      timeout_seconds: cfg.execution?.timeout_seconds != null
+        ? String(cfg.execution.timeout_seconds)
+        : ''
+    },
+    project_inputs: (cfg.project_inputs || []).map(inp => ({
+      input_id: inp.input_id || '',
+      _type: inp.layer !== undefined ? 'layer' : 'value',
+      layer: inp.layer || '',
+      selection_mode: inp.selection?.mode || '',
+      selection_expression: inp.selection?.expression || '',
+      encoding_format: inp.encoding?.format || '',
+      encoding_geometry_only: inp.encoding?.geometry_only || false,
+      value_str: inp.value !== undefined ? JSON.stringify(inp.value) : ''
+    })),
+    payload_bindings: objToKvPairs(cfg.payload_bindings || {})
+  }
+}
+
+export function editToProcess (proc) {
+  const result = {}
+
+  const remote = {}
+  if (proc.remote.type) remote.type = proc.remote.type
+  if (proc.remote.execute_url) remote.execute_url = proc.remote.execute_url
+  if (proc.remote.method) remote.method = proc.remote.method
+  if (proc.remote.status_url) remote.status_url = proc.remote.status_url
+  if (proc.remote.result_url) remote.result_url = proc.remote.result_url
+  const headers = kvPairsToObj(proc.remote.headers)
+  if (Object.keys(headers).length) remote.headers = headers
+  if (Object.keys(remote).length) result.remote = remote
+
+  const execution = { async: proc.execution.async }
+  const poll = proc.execution.poll_interval_seconds
+  if (poll !== '' && poll != null) execution.poll_interval_seconds = Number(poll)
+  const timeout = proc.execution.timeout_seconds
+  if (timeout !== '' && timeout != null) execution.timeout_seconds = Number(timeout)
+  result.execution = execution
+
+  const project_inputs = proc.project_inputs
+    .filter(inp => inp.input_id)
+    .map(inp => {
+      const item = { input_id: inp.input_id }
+      if (inp._type === 'layer') {
+        item.layer = inp.layer
+        if (inp.selection_mode || inp.selection_expression) {
+          item.selection = {}
+          if (inp.selection_mode) item.selection.mode = inp.selection_mode
+          if (inp.selection_expression) item.selection.expression = inp.selection_expression
+        }
+        if (inp.encoding_format || inp.encoding_geometry_only) {
+          item.encoding = {}
+          if (inp.encoding_format) item.encoding.format = inp.encoding_format
+          item.encoding.geometry_only = inp.encoding_geometry_only
+        }
+      } else {
+        try {
+          item.value = JSON.parse(inp.value_str)
+        } catch {
+          item.value = inp.value_str
+        }
+      }
+      return item
+    })
+  if (project_inputs.length) result.project_inputs = project_inputs
+
+  const payload_bindings = kvPairsToObj(proc.payload_bindings)
+  if (Object.keys(payload_bindings).length) result.payload_bindings = payload_bindings
+
+  return result
+}
+
+export function serviceToEdit (svc) {
+  const _processes = Object.entries(svc.processes || {}).map(([id, cfg]) => processToEdit(id, cfg))
+  return {
+    url: svc.url || '',
+    type: svc.type || 'ogc_api_processes',
+    name: svc.name || '',
+    _processes
+  }
+}
+
+export function editToService (edit) {
+  const result = { url: edit.url, type: edit.type }
+  if (edit.name) result.name = edit.name
+  const processes = {}
+  for (const proc of edit._processes) {
+    if (!proc._key) continue
+    processes[proc._key] = editToProcess(proc)
+  }
+  if (Object.keys(processes).length) result.processes = processes
+  return result
+}

--- a/src/utils/processing.js
+++ b/src/utils/processing.js
@@ -14,31 +14,9 @@ export function kvPairsToObj (pairs) {
 export function processToEdit (id, cfg) {
   return {
     _key: id,
-    remote: {
-      type: cfg.remote?.type || '',
-      execute_url: cfg.remote?.execute_url || '',
-      method: cfg.remote?.method || '',
-      status_url: cfg.remote?.status_url || '',
-      result_url: cfg.remote?.result_url || '',
-      headers: objToKvPairs(cfg.remote?.headers || {})
-    },
+    title: cfg.title || '',
+    description: cfg.description || null,
   }
-}
-
-export function editToProcess (proc) {
-  const result = {}
-
-  const remote = {}
-  if (proc.remote.type) remote.type = proc.remote.type
-  if (proc.remote.execute_url) remote.execute_url = proc.remote.execute_url
-  if (proc.remote.method) remote.method = proc.remote.method
-  if (proc.remote.status_url) remote.status_url = proc.remote.status_url
-  if (proc.remote.result_url) remote.result_url = proc.remote.result_url
-  const headers = kvPairsToObj(proc.remote.headers)
-  if (Object.keys(headers).length) remote.headers = headers
-  if (Object.keys(remote).length) result.remote = remote
-
-  return result
 }
 
 export function serviceToEdit (svc) {
@@ -48,18 +26,17 @@ export function serviceToEdit (svc) {
     url: svc.url || '',
     type: svc.type || 'ogcapi-processes',
     name: svc.name || '',
-    _processes
+    _headers: objToKvPairs(svc.headers || {}),
+    _processes,
   }
 }
 
 export function editToService (edit) {
   const result = { url: edit.url, type: edit.type }
   if (edit.name) result.name = edit.name
-  const processes = {}
-  for (const proc of edit._processes) {
-    if (!proc._key) continue
-    processes[proc._key] = editToProcess(proc)
-  }
-  if (Object.keys(processes).length) result.processes = processes
+  const headers = kvPairsToObj(edit._headers || [])
+  if (Object.keys(headers).length) result.headers = headers
+  const processes = (edit._processes || []).filter(p => p._key).map(p => p._key)
+  if (processes.length) result.processes = processes
   return result
 }

--- a/src/utils/processing.js
+++ b/src/utils/processing.js
@@ -22,26 +22,6 @@ export function processToEdit (id, cfg) {
       result_url: cfg.remote?.result_url || '',
       headers: objToKvPairs(cfg.remote?.headers || {})
     },
-    execution: {
-      async: cfg.execution?.async || false,
-      poll_interval_seconds: cfg.execution?.poll_interval_seconds != null
-        ? String(cfg.execution.poll_interval_seconds)
-        : '',
-      timeout_seconds: cfg.execution?.timeout_seconds != null
-        ? String(cfg.execution.timeout_seconds)
-        : ''
-    },
-    project_inputs: (cfg.project_inputs || []).map(inp => ({
-      input_id: inp.input_id || '',
-      _type: inp.layer !== undefined ? 'layer' : 'value',
-      layer: inp.layer || '',
-      selection_mode: inp.selection?.mode || '',
-      selection_expression: inp.selection?.expression || '',
-      encoding_format: inp.encoding?.format || '',
-      encoding_geometry_only: inp.encoding?.geometry_only || false,
-      value_str: inp.value !== undefined ? JSON.stringify(inp.value) : ''
-    })),
-    payload_bindings: objToKvPairs(cfg.payload_bindings || {})
   }
 }
 
@@ -58,51 +38,15 @@ export function editToProcess (proc) {
   if (Object.keys(headers).length) remote.headers = headers
   if (Object.keys(remote).length) result.remote = remote
 
-  const execution = { async: proc.execution.async }
-  const poll = proc.execution.poll_interval_seconds
-  if (poll !== '' && poll != null) execution.poll_interval_seconds = Number(poll)
-  const timeout = proc.execution.timeout_seconds
-  if (timeout !== '' && timeout != null) execution.timeout_seconds = Number(timeout)
-  result.execution = execution
-
-  const project_inputs = proc.project_inputs
-    .filter(inp => inp.input_id)
-    .map(inp => {
-      const item = { input_id: inp.input_id }
-      if (inp._type === 'layer') {
-        item.layer = inp.layer
-        if (inp.selection_mode || inp.selection_expression) {
-          item.selection = {}
-          if (inp.selection_mode) item.selection.mode = inp.selection_mode
-          if (inp.selection_expression) item.selection.expression = inp.selection_expression
-        }
-        if (inp.encoding_format || inp.encoding_geometry_only) {
-          item.encoding = {}
-          if (inp.encoding_format) item.encoding.format = inp.encoding_format
-          item.encoding.geometry_only = inp.encoding_geometry_only
-        }
-      } else {
-        try {
-          item.value = JSON.parse(inp.value_str)
-        } catch {
-          item.value = inp.value_str
-        }
-      }
-      return item
-    })
-  if (project_inputs.length) result.project_inputs = project_inputs
-
-  const payload_bindings = kvPairsToObj(proc.payload_bindings)
-  if (Object.keys(payload_bindings).length) result.payload_bindings = payload_bindings
-
   return result
 }
 
 export function serviceToEdit (svc) {
   const _processes = Object.entries(svc.processes || {}).map(([id, cfg]) => processToEdit(id, cfg))
   return {
+    id: svc.id,
     url: svc.url || '',
-    type: svc.type || 'ogc_api_processes',
+    type: svc.type || 'ogcapi-processes',
     name: svc.name || '',
     _processes
   }

--- a/src/utils/processing.js
+++ b/src/utils/processing.js
@@ -20,7 +20,10 @@ export function processToEdit (id, cfg) {
 }
 
 export function serviceToEdit (svc) {
-  const _processes = Object.entries(svc.processes || {}).map(([id, cfg]) => processToEdit(id, cfg))
+  const order = svc.processOrder || Object.keys(svc.processes || {})
+  const _processes = order
+    .filter(id => svc.processes && svc.processes[id])
+    .map(id => processToEdit(id, svc.processes[id]))
   return {
     id: svc.id,
     url: svc.url || '',

--- a/src/views/ProcessingView.vue
+++ b/src/views/ProcessingView.vue
@@ -78,7 +78,7 @@ export default {
     startAdd () {
       this.selectedId = null
       this.isNew = true
-      this.editingService = { url: '', type: 'ogcapi-processes', name: '', _processes: [] }
+      this.editingService = { url: '', type: 'ogcapi-processes', name: '', _headers: [], _processes: [] }
     },
     cancelAdd () {
       this.isNew = false

--- a/src/views/ProcessingView.vue
+++ b/src/views/ProcessingView.vue
@@ -7,7 +7,7 @@
     <template v-else>
       <services-list
         :services="services"
-        :selected-index="selectedIndex"
+        :selected-id="selectedId"
         :is-new="isNew"
         @select="selectService"
         @add="startAdd"
@@ -47,7 +47,7 @@ export default {
     return {
       fetchTask: TaskState(),
       services: [],
-      selectedIndex: null,
+      selectedId: null,
       editingService: null,
       isNew: false,
       saveTask: TaskState(),
@@ -67,15 +67,15 @@ export default {
         this.services = resp.data.services
       }
     },
-    selectService (index) {
-      this.selectedIndex = index
+    selectService (id) {
+      this.selectedId = id
       this.isNew = false
-      this.editingService = serviceToEdit(this.services[index])
+      this.editingService = serviceToEdit(this.services.find(s => s.id === id))
     },
     startAdd () {
-      this.selectedIndex = null
+      this.selectedId = null
       this.isNew = true
-      this.editingService = { url: '', type: 'ogc_api_processes', name: '', _processes: [] }
+      this.editingService = { url: '', type: 'ogcapi-processes', name: '', _processes: [] }
     },
     cancelAdd () {
       this.isNew = false
@@ -85,31 +85,32 @@ export default {
       const body = editToService(this.editingService)
       const task = this.isNew
         ? this.$http.post(`/api/project/processing/${this.project.name}`, body)
-        : this.$http.put(`/api/project/processing/${this.project.name}/${this.selectedIndex}`, body)
+        : this.$http.put(`/api/project/processing/${this.project.name}/${this.selectedId}`, body)
       const resp = await watchTask(task, this.saveTask)
       if (this.saveTask.success) {
+        const oldIds = new Set(this.services.map(s => s.id))
         this.services = resp.data.services
         if (this.isNew) {
-          this.selectedIndex = this.services.length - 1
+          const added = this.services.find(s => !oldIds.has(s.id))
+          if (added) this.selectedId = added.id
           this.isNew = false
+          this.editingService = serviceToEdit(added || this.services[0])
         }
         this.$notify.success('Processing service saved')
       } else {
         this.$notify.error('Failed to save processing service')
       }
     },
-    async deleteService (index) {
+    async deleteService (id) {
       const resp = await watchTask(
-        this.$http.delete(`/api/project/processing/${this.project.name}/${index}`),
+        this.$http.delete(`/api/project/processing/${this.project.name}/${id}`),
         this.deleteTask
       )
       if (this.deleteTask.success) {
         this.services = resp.data.services
-        if (this.selectedIndex === index) {
-          this.selectedIndex = null
+        if (this.selectedId === id) {
+          this.selectedId = null
           this.editingService = null
-        } else if (this.selectedIndex > index) {
-          this.selectedIndex--
         }
         this.$notify.success('Processing service removed')
       } else {

--- a/src/views/ProcessingView.vue
+++ b/src/views/ProcessingView.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="processing-view page-content f-row light">
+    <div v-if="fetchTask.pending" class="f-col-ac f-grow m-4">
+      <v-spinner/>
+    </div>
+
+    <template v-else>
+      <services-list
+        :services="services"
+        :selected-index="selectedIndex"
+        :is-new="isNew"
+        @select="selectService"
+        @add="startAdd"
+        @delete="deleteService"
+      />
+
+      <service-form
+        v-if="editingService"
+        :service="editingService"
+        :is-new="isNew"
+        :saving="saveTask.pending"
+        @save="saveService"
+        @cancel="cancelAdd"
+      />
+
+      <div v-else class="f-col-ac f-grow m-4">
+        <span class="hint-text">Select a service or add a new one</span>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+import { TaskState, watchTask } from '@/tasks'
+import { serviceToEdit, editToService } from '@/utils/processing'
+import ServicesList from '@/components/processing/ServicesList.vue'
+import ServiceForm from '@/components/processing/ServiceForm.vue'
+
+export default {
+  name: 'ProcessingView',
+  components: { ServicesList, ServiceForm },
+  props: {
+    project: Object,
+    settings: Object
+  },
+  data () {
+    return {
+      fetchTask: TaskState(),
+      services: [],
+      selectedIndex: null,
+      editingService: null,
+      isNew: false,
+      saveTask: TaskState(),
+      deleteTask: TaskState()
+    }
+  },
+  created () {
+    this.loadConfig()
+  },
+  methods: {
+    async loadConfig () {
+      const resp = await watchTask(
+        this.$http.get(`/api/project/processing/${this.project.name}`),
+        this.fetchTask
+      )
+      if (this.fetchTask.success && resp.data?.services) {
+        this.services = resp.data.services
+      }
+    },
+    selectService (index) {
+      this.selectedIndex = index
+      this.isNew = false
+      this.editingService = serviceToEdit(this.services[index])
+    },
+    startAdd () {
+      this.selectedIndex = null
+      this.isNew = true
+      this.editingService = { url: '', type: 'ogc_api_processes', name: '', _processes: [] }
+    },
+    cancelAdd () {
+      this.isNew = false
+      this.editingService = null
+    },
+    async saveService () {
+      const body = editToService(this.editingService)
+      const task = this.isNew
+        ? this.$http.post(`/api/project/processing/${this.project.name}`, body)
+        : this.$http.put(`/api/project/processing/${this.project.name}/${this.selectedIndex}`, body)
+      const resp = await watchTask(task, this.saveTask)
+      if (this.saveTask.success) {
+        this.services = resp.data.services
+        if (this.isNew) {
+          this.selectedIndex = this.services.length - 1
+          this.isNew = false
+        }
+        this.$notify.success('Processing service saved')
+      } else {
+        this.$notify.error('Failed to save processing service')
+      }
+    },
+    async deleteService (index) {
+      const resp = await watchTask(
+        this.$http.delete(`/api/project/processing/${this.project.name}/${index}`),
+        this.deleteTask
+      )
+      if (this.deleteTask.success) {
+        this.services = resp.data.services
+        if (this.selectedIndex === index) {
+          this.selectedIndex = null
+          this.editingService = null
+        } else if (this.selectedIndex > index) {
+          this.selectedIndex--
+        }
+        this.$notify.success('Processing service removed')
+      } else {
+        this.$notify.error('Failed to remove processing service')
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.hint-text {
+  color: #999;
+  font-style: italic;
+}
+</style>

--- a/src/views/ProcessingView.vue
+++ b/src/views/ProcessingView.vue
@@ -19,8 +19,10 @@
         :service="editingService"
         :is-new="isNew"
         :saving="saveTask.pending"
+        :syncing="syncTask.pending"
         @save="saveService"
         @cancel="cancelAdd"
+        @sync="syncService"
       />
 
       <div v-else class="f-col-ac f-grow m-4">
@@ -51,6 +53,7 @@ export default {
       editingService: null,
       isNew: false,
       saveTask: TaskState(),
+      syncTask: TaskState(),
       deleteTask: TaskState()
     }
   },
@@ -99,6 +102,19 @@ export default {
         this.$notify.success('Processing service saved')
       } else {
         this.$notify.error('Failed to save processing service')
+      }
+    },
+    async syncService () {
+      const resp = await watchTask(
+        this.$http.post(`/api/project/processing/${this.project.name}/${this.selectedId}/sync`),
+        this.syncTask
+      )
+      if (this.syncTask.success) {
+        this.services = resp.data.services
+        this.editingService = serviceToEdit(this.services.find(s => s.id === this.selectedId))
+        this.$notify.success('Processes refreshed from remote')
+      } else {
+        this.$notify.error('Failed to refresh processes from remote')
       }
     },
     async deleteService (id) {

--- a/src/views/ProjectView.vue
+++ b/src/views/ProjectView.vue
@@ -90,6 +90,7 @@
           <router-link class="m-2" :to="{name: 'layers'}">Layers</router-link>
           <router-link class="m-2" :to="{name: 'topics'}">Topics</router-link>
           <router-link class="m-2" :to="{name: 'search'}">Search</router-link>
+          <router-link class="m-2" :to="{name: 'processing'}">Processing</router-link>
           <router-link class="m-2" :to="{name: 'access'}">Permissions</router-link>
           <div class="v-separator"/>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -55,11 +55,11 @@ export default defineConfig(({ mode }) => ({
     proxy: {
       "/ws": {
         ws: true,
-        target: 'ws://localhost'
+        target: process.env.WS_PROXY_TARGET || 'ws://localhost'
         // target: 'wss://dev.gisquick.org'
       },
       "/api": {
-        target: 'http://localhost'
+        target: process.env.API_PROXY_TARGET || 'http://localhost'
         // target: 'https://dev.gisquick.org',
         // target: 'https://portal.mapotip.cz:8443/',
         // changeOrigin: true,


### PR DESCRIPTION
# Add Processing configuration tab

This PR adds a "Processing" tab to the project configuration UI, allowing project authors to manage processing services for a published project.

## Design

The new tab lives in `src/components/processing/`. Authors can add, edit, and delete processing services — each identified by a URL, a type (`ogcapi-processes` or `wps`), a display name, and optional custom HTTP headers. Once a service is registered, the tab shows the process descriptions cached by the server and a sync button to refresh/reload them from the remote service on demand.

One thing to note: the rest of gisquick-settings-web only saves on user request - when the user clicks the "save" button in the upper right corner. The new processing tab handles saving independently - on service save. We have only realized that this breaks the settigns-web UX a bit - it's the only tab that behaves differently. I wasn't sure if this was a dealbreaker, so we might want to re-design this before merging.
